### PR TITLE
bulky.py: Handle escaped uris properly.

### DIFF
--- a/usr/lib/bulky/bulky.py
+++ b/usr/lib/bulky/bulky.py
@@ -343,7 +343,8 @@ class MainWindow():
             # we're dealing with a URI, only accept file://
             if not path.startswith("file://"):
                 return
-            path = path.replace("file://", "")
+            f = Gio.File.new_for_uri(path)
+            path = f.get_path()
         if os.path.exists(path):
             file_obj = FileObject(path)
             if file_obj.is_valid:


### PR DESCRIPTION
Nemo uses GFile to build the file list for bulky, which escapes
the uris. When bulky gets the uri list, we can use GFile again to
decode them back into paths.

This fixes the renaming of files with spaces in their name.

It also seems to fix #3
 