### PR TITLE
preserve whitespace in arguments

### DIFF
--- a/usr/bin/bulky
+++ b/usr/bin/bulky
@@ -1,2 +1,2 @@
 #!/bin/bash
-/usr/lib/bulky/bulky.py $@ &
+/usr/lib/bulky/bulky.py "$@" &


### PR DESCRIPTION
Fixes #19

Pass arguments to bulky.py and preserve whitespace inside the arguments.