### PR TITLE
Added unacenting option in change case

### DIFF
--- a/po/bulky-pl.po
+++ b/po/bulky-pl.po
@@ -192,3 +192,7 @@ msgstr "Zamknij"
 #: usr/share/bulky/bulky.ui.h:28
 msgid "Rename"
 msgstr "Zmień nazwę"
+
+#: usr/share/bulky/bulky.ui.h:29
+msgid "Remove accents"
+msgstr "Usuń znaki akcentowane"

--- a/usr/lib/bulky/bulky.py
+++ b/usr/lib/bulky/bulky.py
@@ -10,6 +10,7 @@ import subprocess
 import warnings
 import sys
 import functools
+import unidecode
 
 # Suppress GTK deprecation warnings
 warnings.filterwarnings("ignore")
@@ -348,6 +349,8 @@ class MainWindow():
         self.radio_lowercase = self.builder.get_object("radio_lowercase")
         self.radio_uppercase = self.builder.get_object("radio_uppercase")
         self.radio_firstuppercase = self.builder.get_object("radio_firstuppercase")
+        self.radio_accents = self.builder.get_object("radio_accents")
+
         self.radio_titlecase.connect("toggled", self.on_widget_change)
         self.radio_lowercase.connect("toggled", self.on_widget_change)
         self.radio_uppercase.connect("toggled", self.on_widget_change)
@@ -730,8 +733,10 @@ class MainWindow():
             return string.lower()
         elif self.radio_uppercase.get_active():
             return string.upper()
-        else:
+        elif self.radio_firstuppercase.get_active():
             return string.capitalize()
+        else:
+            return unidecode.unidecode(string)
 
     def inject(self, index, string):
         string = string.replace('%n', "{:01d}".format(index))

--- a/usr/lib/bulky/bulky.py
+++ b/usr/lib/bulky/bulky.py
@@ -355,6 +355,7 @@ class MainWindow():
         self.radio_lowercase.connect("toggled", self.on_widget_change)
         self.radio_uppercase.connect("toggled", self.on_widget_change)
         self.radio_firstuppercase.connect("toggled", self.on_widget_change)
+        self.radio_accents.connect("toggled", self.on_widget_change)
 
         # Tooltips
         variables_tooltip = _("Use %n, %0n, %00n, %000n to enumerate.")

--- a/usr/share/bulky/bulky.ui
+++ b/usr/share/bulky/bulky.ui
@@ -616,10 +616,29 @@
                               </packing>
                             </child>
                             <child>
-                              <placeholder/>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                              </object>
+                              <packing>
+                                <property name="left-attach">0</property>
+                                <property name="top-attach">2</property>
+                              </packing>
                             </child>
                             <child>
-                              <placeholder/>
+                              <object class="GtkRadioButton" id="radio_accents">
+                                <property name="label" translatable="yes">Remove accents</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="halign">start</property>
+                                <property name="draw-indicator">True</property>
+                                <property name="group">radio_uppercase</property>
+                              </object>
+                              <packing>
+                                <property name="left-attach">1</property>
+                                <property name="top-attach">2</property>
+                              </packing>
                             </child>
                             <child>
                               <placeholder/>


### PR DESCRIPTION
Added unacenting option in change case tab, as suggested by Issue #51.

![Zrzut ekranu z 2024-06-09 21-17-51](https://github.com/linuxmint/bulky/assets/80032496/af2183d1-1400-408a-8dd1-82c0c60b9442)