### PR TITLE
change numbering filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Bulky - Rename multiple files at once.
 ![build](https://github.com/linuxmint/bulky/actions/workflows/build.yml/badge.svg)
 
-![image](https://user-images.githubusercontent.com/1138515/119273676-dcc8c100-bc03-11eb-95dd-841a831285cc.png)
+![bulky_1](https://github.com/user-attachments/assets/d8ba440b-5223-4387-904d-62beffec6711)
+
 
 Bulky is used to rename files and directories.
 

--- a/usr/lib/bulky/bulky.py
+++ b/usr/lib/bulky/bulky.py
@@ -2,11 +2,9 @@
 import gettext
 import gi
 import locale
-import magic
 import os
 import re
 import setproctitle
-import subprocess
 import warnings
 import sys
 import functools
@@ -743,7 +741,6 @@ class MainWindow():
         inc  = self.insert_inc_spin.get_value_as_int()
         start= self.insert_start_spin.get_value_as_int()
         text = self.inject((index-1)*inc + start, text)
-        length = len(string) - 1
         from_index = self.insert_spin.get_value_as_int() - 1
         a = len(string)
         b = len(text)

--- a/usr/lib/bulky/bulky.py
+++ b/usr/lib/bulky/bulky.py
@@ -313,6 +313,19 @@ class MainWindow():
         self.replace_regex_check.connect("toggled", self.on_widget_change)
         self.replace_case_check.connect("toggled", self.on_widget_change)
 
+        self.replace_start_spin = self.builder.get_object("replace_start_spin")
+        self.replace_start_spin.connect("value-changed", self.on_widget_change)
+        self.replace_start_spin.set_range(0, 10000)
+        self.replace_start_spin.set_value(1)
+        self.replace_start_spin.set_increments(1, 10)
+
+        self.replace_inc_spin = self.builder.get_object("replace_inc_spin")
+        self.replace_inc_spin.connect("value-changed", self.on_widget_change)
+        self.replace_inc_spin.set_range(1, 1000)
+        self.replace_inc_spin.set_value(1)
+        self.replace_inc_spin.set_increments(1, 10)
+
+
         # Set focus chain
         # Not that this is deprecated (but not implemented differently) in Gtk3.
         # If we move to GTK4, we'll just drop this line of code.
@@ -328,9 +341,9 @@ class MainWindow():
         self.remove_from_check.connect("toggled", self.on_widget_change)
         self.remove_to_check.connect("toggled", self.on_widget_change)
         self.remove_from_spin.set_range(1, 100)
-        self.remove_from_spin.set_increments(1, 1)
+        self.remove_from_spin.set_increments(1, 10)
         self.remove_to_spin.set_range(1, 100)
-        self.remove_to_spin.set_increments(1, 1)
+        self.remove_to_spin.set_increments(1, 10)
 
         # Insert widgets
         self.insert_entry = self.builder.get_object("insert_entry")
@@ -342,7 +355,20 @@ class MainWindow():
         self.insert_reverse_check.connect("toggled", self.on_widget_change)
         self.overwrite_check.connect("toggled", self.on_widget_change)
         self.insert_spin.set_range(1, 100)
-        self.insert_spin.set_increments(1, 1)
+        self.insert_spin.set_increments(1, 10)
+
+        self.insert_start_spin = self.builder.get_object("insert_start_spin")
+        self.insert_start_spin.connect("value-changed", self.on_widget_change)
+        self.insert_start_spin.set_range(0, 10000)
+        self.insert_start_spin.set_value(1)
+        self.insert_start_spin.set_increments(1, 10)
+
+        self.insert_inc_spin = self.builder.get_object("insert_inc_spin")
+        self.insert_inc_spin.connect("value-changed", self.on_widget_change)
+        self.insert_inc_spin.set_range(1, 1000)
+        self.insert_inc_spin.set_value(1)
+        self.insert_inc_spin.set_increments(1, 10)
+
 
         # Case widgets
         self.radio_titlecase = self.builder.get_object("radio_titlecase")
@@ -358,7 +384,7 @@ class MainWindow():
         self.radio_accents.connect("toggled", self.on_widget_change)
 
         # Tooltips
-        variables_tooltip = _("Use %n, %0n, %00n, %000n to enumerate.")
+        variables_tooltip = _("Use %n, %0n, %00n, %000n, etc. to enumerate.")
         self.replace_entry.set_tooltip_text(variables_tooltip)
         self.insert_entry.set_tooltip_text(variables_tooltip)
 
@@ -673,8 +699,12 @@ class MainWindow():
         case = self.replace_case_check.get_active()
         regex = self.replace_regex_check.get_active()
         find = self.find_entry.get_text()
+        if not find:  #ignore empty search string
+            return string
+        inc  = self.replace_inc_spin.get_value_as_int()
+        start= self.replace_start_spin.get_value_as_int()
         replace = self.replace_entry.get_text()
-        replace = self.inject(index, replace)
+        replace = self.inject((index-1)*inc + start, replace)
         try:
             if regex:
                 if case:
@@ -710,7 +740,9 @@ class MainWindow():
 
     def insert_text(self, index, string):
         text = self.insert_entry.get_text()
-        text = self.inject(index, text)
+        inc  = self.insert_inc_spin.get_value_as_int()
+        start= self.insert_start_spin.get_value_as_int()
+        text = self.inject((index-1)*inc + start, text)
         length = len(string) - 1
         from_index = self.insert_spin.get_value_as_int() - 1
         a = len(string)
@@ -740,11 +772,11 @@ class MainWindow():
             return unidecode.unidecode(string)
 
     def inject(self, index, string):
-        string = string.replace('%n', "{:01d}".format(index))
-        string = string.replace('%0n', "{:02d}".format(index))
-        string = string.replace('%00n', "{:03d}".format(index))
-        string = string.replace('%000n', "{:04d}".format(index))
-        return string
+        def repl(match):
+            zeros = match.group(1)
+            width = len(zeros) + 1
+            return f"{index:0{width}d}"
+        return re.sub(r'%([0]*)n', repl, string)
 
 '''
 TODO

--- a/usr/share/bulky/bulky.ui
+++ b/usr/share/bulky/bulky.ui
@@ -10,7 +10,7 @@
     <property name="can-focus">False</property>
     <property name="border-width">0</property>
     <property name="default-width">600</property>
-    <property name="default-height">400</property>
+    <property name="default-height">500</property>
     <property name="icon-name">bulky</property>
     <child>
       <object class="GtkBox">

--- a/usr/share/bulky/bulky.ui
+++ b/usr/share/bulky/bulky.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkMenu" id="main_menu">
@@ -395,10 +395,67 @@
                               </packing>
                             </child>
                             <child>
-                              <placeholder/>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label" translatable="yes">Start number:</property>
+                              </object>
+                              <packing>
+                                <property name="left-attach">0</property>
+                                <property name="top-attach">2</property>
+                              </packing>
                             </child>
                             <child>
-                              <placeholder/>
+                              <object class="GtkBox">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="spacing">12</property>
+                                <child>
+                                  <object class="GtkSpinButton" id="replace_start_spin">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="halign">start</property>
+                                    <property name="numeric">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">Increment:</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkSpinButton" id="replace_inc_spin">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="halign">start</property>
+                                    <property name="numeric">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">2</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="left-attach">1</property>
+                                <property name="top-attach">2</property>
+                              </packing>
                             </child>
                             <child>
                               <placeholder/>
@@ -449,6 +506,7 @@
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
                                     <property name="halign">start</property>
+                                    <property name="numeric">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -503,10 +561,67 @@
                               </packing>
                             </child>
                             <child>
-                              <placeholder/>
+                              <object class="GtkBox">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="spacing">12</property>
+                                <child>
+                                  <object class="GtkSpinButton" id="insert_start_spin">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="halign">start</property>
+                                    <property name="numeric">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">Increment:</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkSpinButton" id="insert_inc_spin">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="halign">start</property>
+                                    <property name="numeric">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">2</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="left-attach">1</property>
+                                <property name="top-attach">2</property>
+                              </packing>
                             </child>
                             <child>
-                              <placeholder/>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label" translatable="yes">Start number:</property>
+                              </object>
+                              <packing>
+                                <property name="left-attach">0</property>
+                                <property name="top-attach">2</property>
+                              </packing>
                             </child>
                             <child>
                               <placeholder/>


### PR DESCRIPTION
For numbering filenames, added a spin box for the starting number and a spin box for the step size of the numbering in GTK ui file. Did this for both the replace and insert widgets.
Modified the Python code for the replace and insert functions accordingly.

In the replace function, ignore empty find string inputs to avoid unexpected replacement behavior.

The inject function has been modified to allow larger numbers with leading zeros (%n, %0n, %000000n, etc).

fix issue #63 and #66(partly?)
