### PR TITLE
Assume path is writeable for GVfs mounted paths

### DIFF
--- a/bulky.pot
+++ b/bulky.pot
@@ -62,6 +62,11 @@ msgstr ""
 msgid "Unable to rename '%s': File name too long"
 msgstr ""
 
+#: usr/lib/bulky/bulky.py:517
+#, python-format
+msgid "Unable to rename '%s': Remote operation failed. This may be due to insufficient permissions or a server error."
+msgstr ""
+
 #: usr/lib/bulky/bulky.py:481
 #, python-format
 msgid "Unable to rename '%s': %s"

--- a/usr/lib/bulky/bulky.py
+++ b/usr/lib/bulky/bulky.py
@@ -165,7 +165,10 @@ class FileObject():
             return parent.get_basename()
 
     def writable(self):
-        return self.info.get_attribute_boolean("access::can-write")
+        if self.gfile.is_native():
+            return self.info.get_attribute_boolean("access::can-write")
+        # For non-native (remote) files, optimistically assume writable
+        return True
 
     def parent_writable(self):
         parent = self.gfile.get_parent()
@@ -505,6 +508,10 @@ class MainWindow():
         # to add more exceptions here for other error codes.
         if Gio.IOErrorEnum(error.code) == Gio.IOErrorEnum.FILENAME_TOO_LONG:
             message = _("Unable to rename '%s': File name too long") \
+                % file_obj.get_path_or_uri_for_display()
+        elif not file_obj.gfile.is_native() and error.code == 0:
+            message = _("Unable to rename '%s': Remote operation failed. " \
+                "This may be due to insufficient permissions or a server error.") \
                 % file_obj.get_path_or_uri_for_display()
         else:
             message = _("Unable to rename '%s': %s") \


### PR DESCRIPTION
Hello maintainers,

This pull request fixes issue #57 

### Cause
The issue is caused by the check, done by the writable method. Paths mounted via Nemo do not show any `access::can-write` property, even though Nemo or a terminal can modify these paths.
```
cagdas@cagdas-mint:~/source/bulky/usr/share$ gio info /run/user/1000/gvfs/ftp:host=cagdas-mint.local,port=2121
display name: / on cagdas-mint.local:2121
edit name: /
name: /
type: directory
uri: ftp://cagdas-mint.local:2121/
local path: /run/user/1000/gvfs/ftp:host=cagdas-mint.local,port=2121
unix mount: gvfsd-fuse /run/user/1000/gvfs fuse.gvfsd-fuse rw,nosuid,nodev,relatime,user_id=1000,group_id=1000
attributes:
  standard::type: 2
  standard::is-symlink: FALSE
  standard::name: /
  standard::display-name: / on cagdas-mint.local:2121
  standard::edit-name: /
  standard::icon: folder-remote, folder-remote-symbolic
  standard::content-type: inode/directory
  standard::fast-content-type: inode/directory
  standard::symbolic-icon: folder-remote-symbolic, folder-remote
  id::filesystem: ftp:host=cagdas-mint.local,port=2121
  metadata::nemo-list-view-sort-column: name
  metadata::nemo-list-view-sort-reversed: false
```

 So the `writeables` method returns `False` for these paths, causing bulky to display a warning.
```
  def writable(self):
          return self.info.get_attribute_boolean("access::can-write")
```
### Fix

I've made the necessary changes to optimistically allow remote paths to be added. So the user can add remote paths and try to run the update on them. Only then, if the operation fails, bulky will show an error by the `report_os_error` method. (This is also what Nemo does.)
I've also modified this method to print a better clue so the user will have a good idea about what could be going wrong. 

### Notes
I was expecting to use the `GLib.Error`'s `code` property to display the issue, but apparently remote backends ( like FTP,SMB etc.) do not map server errors to the GIO error codes. So we have a more generic error, but I believe it is okay. Because if bulky can't make changes, the user also won't be able to make changes using Nemo or other tools. So the warning is helpful, I believe.

### Image
![image](https://github.com/user-attachments/assets/f142c165-3821-4bb6-b597-ee3147d600f8)
