### PR TITLE
Autosize columns after a line is deleted

### DIFF
--- a/usr/lib/bulky/bulky.py
+++ b/usr/lib/bulky/bulky.py
@@ -472,6 +472,7 @@ class MainWindow():
             file_uri = self.model.get_value(iter, COL_FILE).uri
             self.uris.remove(file_uri)
             self.model.remove(iter)
+        self.treeview.columns_autosize()
         self.preview_changes()
 
     def on_add_button(self, widget):


### PR DESCRIPTION
### Issue
Columns do not resize after a file is deleted from the treeview.
![bug](https://github.com/user-attachments/assets/300fc0e2-2e0e-48d1-a583-81cc120ee815)

### Fix
Call `autosize` after a delete operation.
![fix](https://github.com/user-attachments/assets/b70b2eee-3825-41e9-8cce-98735867ef91)
